### PR TITLE
Fix for numpy 1.25+

### DIFF
--- a/pyswipe/plot_utils.py
+++ b/pyswipe/plot_utils.py
@@ -573,7 +573,7 @@ class Polarplot(object):
         if verbose:
             print(lt.shape, lat.shape, latres.shape, ltres.shape)
 
-        la = np.vstack(((lt - 6) / 12. * np.pi + i * ltres / (resolution - 1.) / 12. * np.pi for i in range(resolution))).T
+        la = np.vstack([(lt - 6) / 12. * np.pi + i * ltres / (resolution - 1.) / 12. * np.pi for i in range(resolution)]).T
         if verbose:
             print (la.shape)
         ua = la[:, ::-1]


### PR DESCRIPTION
I haven't found if this was announced somewhere but it looks like newer versions of numpy don't allow passing a generator here so I turned it into a list comprehension

This is needed to make pyswipe work on the updated VRE now